### PR TITLE
Fix nested lists styling

### DIFF
--- a/src/global-styles/prose.css
+++ b/src/global-styles/prose.css
@@ -40,14 +40,17 @@
     list-style-type: disc;
     list-style-position: outside;
     padding-left: 1em;
+
+    /* nested lists are the worse */
+    text-indent: 0;
   }
 
   & ol {
-    counter-reset: ol;
+    counter-reset: ol var(--start, 0);
     list-style-type: none;
     padding: 0;
 
-    & li {
+    & > li {
       text-indent: -1.5em;
       padding-left: 1.5em;
 
@@ -69,6 +72,10 @@
         margin-right: 0.5em;
         user-select: none;
       }
+    }
+
+    & li > p {
+      display: contents;
     }
   }
 

--- a/src/lib/OrderedList.tsx
+++ b/src/lib/OrderedList.tsx
@@ -1,0 +1,13 @@
+import type { JSX } from "solid-js/jsx-runtime";
+
+export function OrderedList(props: JSX.HTMLAttributes<HTMLOListElement>) {
+  return (
+    <ol
+      {...props}
+      style={{
+        ...(props.style as object),
+        "--start": (props as { start?: number | string }).start || 0,
+      }}
+    />
+  );
+}

--- a/src/pages/[...path].astro
+++ b/src/pages/[...path].astro
@@ -1,5 +1,6 @@
 ---
 import { Link } from "../lib/Link";
+import { OrderedList } from "../lib/OrderedList";
 import type { PostFrontmatter } from "../types";
 
 export const getStaticPaths = async () => {
@@ -19,6 +20,7 @@ const { Content } = Astro.props;
 
 const mdxComponents = {
   a: Link,
+  ol: OrderedList,
 };
 
 // You can find the UI layout for the post in src/layouts/PostLayout.astro


### PR DESCRIPTION
### Lists written with newlines will now look exactly as the lists written without — due to `display: contents` in the styles.

```
1. a

2. a

3. a
```


```
1. a
2. a
3. a
```

### `ol` lists will now respect `start` attribute received from markdown

We're using a Custom CSS Property to reset the counter.