### PR TITLE
Remove overflow from code-container

### DIFF
--- a/src/global-styles/shiki.css
+++ b/src/global-styles/shiki.css
@@ -81,9 +81,6 @@ pre.twoslash data-lsp:hover::before {
   z-index: 100;
 }
 
-pre .code-container {
-  overflow: auto;
-}
 /* The try button */
 pre .code-container > a {
   position: absolute;


### PR DESCRIPTION
`pre` already has `overflow: auto`.

Before:
<img width="403" alt="CleanShot 2022-11-19 at 08 18 28@2x" src="https://user-images.githubusercontent.com/9019397/202823780-d4645e56-16f8-4a7c-b088-8a945b050c19.png">

After:
<img width="465" alt="CleanShot 2022-11-19 at 08 19 40@2x" src="https://user-images.githubusercontent.com/9019397/202823772-3d25cb58-22cf-4913-804b-96e19538dda2.png">

