### PR TITLE
Break long links

### DIFF
--- a/src/global-styles/prose.css
+++ b/src/global-styles/prose.css
@@ -3,6 +3,24 @@
   --wide-content-width: min(100vw, calc(var(--container-width) * 1.2));
 }
 
+.dont-break-out {
+  /* These are technically the same, but use both */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+  /* Instead use this non-standard one: */
+  word-break: break-word;
+
+  /* Adds a hyphen where the word breaks, if supported (No Blink) */
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
 .zaduma-prose {
   /* TODO: Get rid of thesse two and apply Tailwind styles */
   --sans: "Inter";
@@ -30,7 +48,7 @@
     text-overflow: ellipsis;
 
     & a {
-      white-space: nowrap;
+      @apply dont-break-out;
       max-width: var(--container-width);
     }
   }


### PR DESCRIPTION
Long links were causing overflow on small screens. 

![CleanShot 2023-01-07 at 12 00 22@2x](https://user-images.githubusercontent.com/9019397/211147093-34c32ff7-75ba-470b-b258-01a223d4eb40.png)
<img width="523" alt="CleanShot 2023-01-07 at 12 00 44@2x" src="https://user-images.githubusercontent.com/9019397/211147097-b8b43066-30cd-42b9-ba85-78892dd1b1a9.png">


