### PR TITLE
Change text size to 1.125rem in Safari inputs

### DIFF
--- a/src/global-styles/controls.css
+++ b/src/global-styles/controls.css
@@ -7,3 +7,15 @@
     focus:before:bg-gray-100 dark:focus:before:bg-gray-800/60
     selected:before:bg-gray-100 dark:selected:before:bg-gray-800/60;
 }
+
+/*
+ * This isn't needed if your base font-size is 16px or higher.
+ * IOS Safari zooms in on inputs on focus if their text size is smaller than 16px.
+ */
+@supports (-webkit-overflow-scrolling: touch) {
+  input,
+  textarea,
+  select {
+    @apply text-lg;
+  }
+}


### PR DESCRIPTION
Further Reading: https://www.google.com/search?q=mobile+safari+zooms+input&sourceid=chrome&ie=UTF-8