### PR TITLE
feat: make the starter agent-ready (sitemap, robots, llms.txt, JSON-LD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ screenshots
 test-results
 playwright-report
 .pnpm-store
+.env.agent-ci

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,5 @@
 import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 import solidJs from "@astrojs/solid-js";
 import tailwind from "@astrojs/tailwind";
 import { transformerTwoslash } from "@shikijs/twoslash";
@@ -62,6 +63,7 @@ export default defineConfig({
       rehypePlugins: rehypePlugins,
     }),
     solidJs(),
+    sitemap(),
   ],
   vite: {
     ssr: {

--- a/e2e/agent-ready.spec.ts
+++ b/e2e/agent-ready.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("agent-ready endpoints", () => {
+  test("/robots.txt allows AI bots and links to sitemap", async ({
+    request,
+  }) => {
+    const res = await request.get("/robots.txt");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+
+    expect(body).toMatch(/^User-agent: \*\nAllow: \//m);
+
+    const bots = [
+      "GPTBot",
+      "ClaudeBot",
+      "ClaudeUser",
+      "PerplexityBot",
+      "Google-Extended",
+      "CCBot",
+      "Applebot-Extended",
+      "Bytespider",
+      "Amazonbot",
+    ];
+    for (const bot of bots) {
+      expect(body).toContain(`User-agent: ${bot}`);
+    }
+
+    expect(body).toContain("Content-Signals: search, ai-train: yes");
+    expect(body).toMatch(/^Sitemap: https?:\/\/.+\/sitemap-index\.xml$/m);
+  });
+
+  test("/sitemap-index.xml is emitted and references a sitemap", async ({
+    request,
+  }) => {
+    const res = await request.get("/sitemap-index.xml");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<sitemapindex");
+    expect(body).toMatch(/<loc>[^<]+sitemap-\d+\.xml<\/loc>/);
+  });
+
+  test("/llms.txt lists posts in the expected shape", async ({ request }) => {
+    const res = await request.get("/llms.txt");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+
+    expect(body).toMatch(/^# .+/m);
+    expect(body).toContain("## Posts");
+    // At least one known post rendered as `- [Title](absolute-url)`
+    expect(body).toMatch(
+      /- \[Asides\]\(https?:\/\/[^)]+\/features\/asides\)/,
+    );
+  });
+
+  test("/llms-full.txt concatenates raw post bodies without frontmatter", async ({
+    request,
+  }) => {
+    const res = await request.get("/llms-full.txt");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+
+    expect(body).toContain("# Asides");
+    expect(body).toContain("---"); // separator between posts
+    // Frontmatter fences should be stripped — the file starts with `---\ntags:`,
+    // so a leading `tags:` line would prove we leaked frontmatter.
+    expect(body).not.toMatch(/^tags:\s*\[/m);
+  });
+
+  test("/<post>.md returns raw markdown body with the title heading", async ({
+    request,
+  }) => {
+    const res = await request.get("/features/asides.md");
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+    expect(body.startsWith("# Asides")).toBe(true);
+    expect(body).not.toMatch(/^---\n/);
+  });
+});
+
+test.describe("head metadata for agents", () => {
+  test("post page has canonical, markdown alt, and JSON-LD", async ({
+    page,
+  }) => {
+    await page.goto("/features/asides/");
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveAttribute(
+      "href",
+      /https?:\/\/.+\/features\/asides\/?$/,
+    );
+
+    const mdAlt = page.locator(
+      'link[rel="alternate"][type="text/markdown"]',
+    );
+    await expect(mdAlt).toHaveAttribute(
+      "href",
+      /https?:\/\/.+\/features\/asides\.md$/,
+    );
+
+    const jsonLdBlocks = await page
+      .locator('script[type="application/ld+json"]')
+      .allTextContents();
+    const parsed = jsonLdBlocks.map((t) => JSON.parse(t));
+    const types = parsed.map((p) => p["@type"]);
+    expect(types).toContain("WebSite");
+    expect(types).toContain("BlogPosting");
+
+    const post = parsed.find((p) => p["@type"] === "BlogPosting");
+    expect(post.headline).toBe("Asides");
+    expect(typeof post.datePublished).toBe("string");
+    expect(post.mainEntityOfPage["@id"]).toMatch(/\/features\/asides\/?$/);
+  });
+
+  test("homepage has canonical but no markdown alternate", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      /https?:\/\/.+\/$/,
+    );
+    await expect(
+      page.locator('link[rel="alternate"][type="text/markdown"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^6.3.10",
     "@astrojs/mdx": "^4.3.13",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/solid-js": "^5.1.3",
     "@astrojs/tailwind": "^6.0.2",
     "@fontsource-variable/brygada-1918": "^5.0.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.3.13
         version: 4.3.13(astro@5.17.2(@types/node@20.13.0)(jiti@1.21.0)(rollup@4.57.1)(tsx@4.11.0)(typescript@5.8.3)(yaml@2.4.2))
+      '@astrojs/sitemap':
+        specifier: ^3.7.2
+        version: 3.7.2
       '@astrojs/solid-js':
         specifier: ^5.1.3
         version: 5.1.3(@types/node@20.13.0)(jiti@1.21.0)(solid-js@1.8.17)(tsx@4.11.0)(yaml@2.4.2)
@@ -177,6 +180,9 @@ packages:
 
   '@astrojs/rss@4.0.15':
     resolution: {integrity: sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==}
+
+  '@astrojs/sitemap@3.7.2':
+    resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
   '@astrojs/solid-js@5.1.3':
     resolution: {integrity: sha512-KxfYt4y1d7BuSw6EsN1EaPoGYsIES7bEI6AtTbncuabRUUMZs+mOWOeOdmgnwVLj+jbNbhBjUZsqr77eUviZdw==}
@@ -1371,11 +1377,17 @@ packages:
   '@types/node@20.13.0':
     resolution: {integrity: sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/prop-types@15.7.12':
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -4491,6 +4503,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4532,6 +4549,9 @@ packages:
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   stream-to-array@2.3.0:
     resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
@@ -4850,6 +4870,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -5252,6 +5275,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -5325,6 +5351,12 @@ snapshots:
     dependencies:
       fast-xml-parser: 5.3.6
       piccolore: 0.1.3
+
+  '@astrojs/sitemap@3.7.2':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.3.6
 
   '@astrojs/solid-js@5.1.3(@types/node@20.13.0)(jiti@1.21.0)(solid-js@1.8.17)(tsx@4.11.0)(yaml@2.4.2)':
     dependencies:
@@ -6309,12 +6341,20 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/prop-types@15.7.12': {}
 
   '@types/react@18.3.3':
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 20.13.0
 
   '@types/semver@7.5.8': {}
 
@@ -10301,6 +10341,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.4.4
+
   slash@3.0.0: {}
 
   smol-toml@1.6.0: {}
@@ -10331,6 +10378,8 @@ snapshots:
   stat-mode@0.3.0: {}
 
   statuses@1.5.0: {}
+
+  stream-replace-string@2.0.0: {}
 
   stream-to-array@2.3.0:
     dependencies:
@@ -10759,6 +10808,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@7.16.0: {}
+
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -11117,5 +11168,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,6 +7,8 @@ import { Commands } from "../lib/Commands";
 import GrainOverlay from "../lib/GrainOverlay/GrainOverlay.astro";
 import { Link } from "../lib/Link";
 import ScrollbarStyles from "../lib/ScrollbarStyles.astro";
+import { websiteSchema } from "../lib/seo/jsonLd";
+import JsonLd from "../lib/seo/JsonLd.astro";
 import SocialCardMetaTags from "../lib/SocialCardMetaTags.astro";
 import type { PostFrontmatter } from "../types";
 
@@ -29,16 +31,35 @@ const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
   "../../posts/**/*.mdx",
   { eager: true },
 );
-const posts = Object.values(postModules)
-  .filter((p) => (import.meta.env.PROD ? !p.frontmatter.draft : true))
+const postEntries = Object.values(postModules).filter((p) =>
+  import.meta.env.PROD ? !p.frontmatter.draft : true,
+);
+const posts = postEntries
   .map((p) => ({
     href: p.frontmatter.path,
     title: p.frontmatter.title,
     date: p.frontmatter.date,
-  }));
+  }))
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
-posts.sort((a, b) => {
-  return new Date(b.date).getTime() - new Date(a.date).getTime();
+const postPaths = new Set(posts.map((p) => p.href));
+
+// Normalize trailing slash before lookup
+const rawPathname = Astro.url.pathname.replace(/\/$/, "") || "/";
+const isPostRoute = postPaths.has(rawPathname);
+
+const canonical = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).href
+  : Astro.url.pathname;
+
+const markdownAlt = Astro.site
+  ? new URL(rawPathname + ".md", Astro.site).href
+  : rawPathname + ".md";
+
+// TODO(downstream): override with real site name + author.
+const websiteData = websiteSchema({
+  name: "Zaduma",
+  url: Astro.site ? Astro.site.href : Astro.url.origin + "/",
 });
 ---
 
@@ -61,9 +82,18 @@ posts.sort((a, b) => {
 
     <SocialCardMetaTags ogImage={ogImage} />
 
+    <link rel="canonical" href={canonical} />
+    {
+      isPostRoute && (
+        <link rel="alternate" type="text/markdown" href={markdownAlt} />
+      )
+    }
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
     <title>{title}</title>
+    <JsonLd data={websiteData} />
+    <slot name="head" />
     <InitColorScheme />
   </head>
   <body>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -4,6 +4,8 @@ import type { MarkdownLayoutProps } from "astro";
 import { createOgImageLink } from "../lib/createOgImageLink";
 import { formatDate } from "../lib/formatDate";
 import Image from "../lib/prose/Image.astro";
+import { blogPostingSchema } from "../lib/seo/jsonLd";
+import JsonLd from "../lib/seo/JsonLd.astro";
 import TableOfContents from "../lib/TableOfContents/TableOfContents.astro";
 import type { PostFrontmatter } from "../types";
 
@@ -23,9 +25,22 @@ const date = new Date(frontmatter.date);
 const imgSrc =
   typeof frontmatter.img === "object" ? frontmatter.img.src : frontmatter.img;
 const description = frontmatter.description || ""
+
+const canonical = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).href
+  : Astro.url.pathname;
+
+// TODO(downstream): set author (Person/Organization) per site.
+const postSchema = blogPostingSchema({
+  headline: frontmatter.title,
+  datePublished: date.toISOString(),
+  description: frontmatter.description,
+  canonical,
+});
 ---
 
 <BaseLayout title={frontmatter.title} ogImage={ogImage} description={description}>
+  <JsonLd data={postSchema} slot="head" />
   <main class="zaduma-prose py-4">
     <header
       class="flex justify-between items-start sm:items-center flex-col sm:flex-row"

--- a/src/lib/seo/JsonLd.astro
+++ b/src/lib/seo/JsonLd.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  data: unknown;
+}
+
+const { data } = Astro.props;
+const json = JSON.stringify(data);
+---
+
+<script type="application/ld+json" is:inline set:html={json} />

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -1,0 +1,64 @@
+export interface AuthorRef {
+  "@type": "Person" | "Organization";
+  name: string;
+  url?: string;
+}
+
+export interface WebSiteSchema {
+  "@context": "https://schema.org";
+  "@type": "WebSite";
+  name: string;
+  url: string;
+  inLanguage: string;
+  author?: AuthorRef;
+}
+
+export interface BlogPostingSchema {
+  "@context": "https://schema.org";
+  "@type": "BlogPosting";
+  headline: string;
+  datePublished: string;
+  dateModified?: string;
+  description?: string;
+  author?: AuthorRef;
+  mainEntityOfPage: { "@type": "WebPage"; "@id": string };
+  inLanguage?: string;
+}
+
+export function websiteSchema(input: {
+  name: string;
+  url: string;
+  inLanguage?: string;
+  author?: AuthorRef;
+}): WebSiteSchema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: input.name,
+    url: input.url,
+    inLanguage: input.inLanguage ?? "en",
+    ...(input.author ? { author: input.author } : {}),
+  };
+}
+
+export function blogPostingSchema(input: {
+  headline: string;
+  datePublished: string;
+  dateModified?: string;
+  description?: string;
+  author?: AuthorRef;
+  canonical: string;
+  inLanguage?: string;
+}): BlogPostingSchema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: input.headline,
+    datePublished: input.datePublished,
+    ...(input.dateModified ? { dateModified: input.dateModified } : {}),
+    ...(input.description ? { description: input.description } : {}),
+    ...(input.author ? { author: input.author } : {}),
+    mainEntityOfPage: { "@type": "WebPage", "@id": input.canonical },
+    inLanguage: input.inLanguage ?? "en",
+  };
+}

--- a/src/pages/[...path].md.ts
+++ b/src/pages/[...path].md.ts
@@ -1,0 +1,42 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+
+import type { PostFrontmatter } from "../types";
+
+const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
+  "../../posts/**/*.mdx",
+  { eager: true },
+);
+
+const rawModules = import.meta.glob<string>("../../posts/**/*.mdx", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+});
+
+function stripFrontmatter(source: string): string {
+  if (!source.startsWith("---")) return source;
+  const end = source.indexOf("\n---", 3);
+  if (end === -1) return source;
+  return source.slice(end + 4).replace(/^\r?\n/, "");
+}
+
+export const getStaticPaths: GetStaticPaths = () => {
+  let entries = Object.entries(postModules);
+
+  if (import.meta.env.PROD) {
+    entries = entries.filter(([, m]) => !m.frontmatter.draft);
+  }
+
+  return entries.map(([key, mod]) => ({
+    params: { path: mod.frontmatter.path.replace(/^\//, "") },
+    props: { raw: rawModules[key] ?? "", title: mod.frontmatter.title },
+  }));
+};
+
+export const GET: APIRoute = ({ props }) => {
+  const { raw, title } = props as { raw: string; title: string };
+  const body = `# ${title}\n\n${stripFrontmatter(raw).trim()}\n`;
+  return new Response(body, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,41 @@
+import type { APIRoute } from "astro";
+
+import type { PostFrontmatter } from "../types";
+
+const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
+  "../../posts/**/*.mdx",
+  { eager: true },
+);
+
+const rawModules = import.meta.glob<string>("../../posts/**/*.mdx", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+});
+
+function stripFrontmatter(source: string): string {
+  if (!source.startsWith("---")) return source;
+  const end = source.indexOf("\n---", 3);
+  if (end === -1) return source;
+  return source.slice(end + 4).replace(/^\r?\n/, "");
+}
+
+export const GET: APIRoute = () => {
+  const entries = Object.entries(postModules)
+    .filter(([, m]) => !m.frontmatter.draft)
+    .sort(
+      ([, a], [, b]) =>
+        new Date(b.frontmatter.date).getTime() -
+        new Date(a.frontmatter.date).getTime(),
+    );
+
+  const chunks: string[] = [];
+  for (const [key, { frontmatter }] of entries) {
+    const raw = rawModules[key] ?? "";
+    chunks.push(`# ${frontmatter.title}\n\n${stripFrontmatter(raw).trim()}\n`);
+  }
+
+  return new Response(chunks.join("\n---\n\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from "astro";
+
+import type { PostFrontmatter } from "../types";
+
+// TODO(downstream): override site name + blurb per site.
+const SITE_NAME = "Zaduma";
+const BLURB = "A blog.";
+
+const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
+  "../../posts/**/*.mdx",
+  { eager: true },
+);
+
+export const GET: APIRoute = ({ site }) => {
+  if (!site) {
+    throw new Error("`site` must be set in astro.config for llms.txt");
+  }
+
+  const posts = Object.values(postModules)
+    .filter((p) => !p.frontmatter.draft)
+    .sort(
+      (a, b) =>
+        new Date(b.frontmatter.date).getTime() -
+        new Date(a.frontmatter.date).getTime(),
+    );
+
+  const lines: string[] = [];
+  lines.push(`# ${SITE_NAME}`);
+  lines.push("");
+  lines.push(`> ${BLURB}`);
+  lines.push("");
+  lines.push("## Posts");
+  lines.push("");
+
+  for (const { frontmatter } of posts) {
+    const url = new URL(frontmatter.path, site).href;
+    const desc = frontmatter.description?.trim() ?? "";
+    const suffix = desc ? `: ${desc}` : "";
+    lines.push(`- [${frontmatter.title}](${url})${suffix}`);
+  }
+
+  return new Response(lines.join("\n") + "\n", {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from "astro";
+
+// AI/LLM training & answer-engine crawlers. Default to Allow so the starter
+// is "agent-ready"; downstream sites can override this list.
+const AI_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "ClaudeUser",
+  "PerplexityBot",
+  "Google-Extended",
+  "CCBot",
+  "Applebot-Extended",
+  "Bytespider",
+  "Amazonbot",
+];
+
+// https://contentsignals.org — opt-in signal for how crawled content may be used.
+const CONTENT_SIGNALS = "search, ai-train: yes";
+
+export const GET: APIRoute = ({ site }) => {
+  if (!site) {
+    throw new Error("`site` must be set in astro.config for robots.txt");
+  }
+
+  const lines: string[] = [];
+
+  lines.push("User-agent: *");
+  lines.push("Allow: /");
+  lines.push("");
+
+  for (const bot of AI_BOTS) {
+    lines.push(`User-agent: ${bot}`);
+    lines.push("Allow: /");
+    lines.push("");
+  }
+
+  lines.push(`Content-Signals: ${CONTENT_SIGNALS}`);
+  lines.push(`Sitemap: ${new URL("sitemap-index.xml", site).href}`);
+
+  return new Response(lines.join("\n") + "\n", {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
Implements the generic, downstream-agnostic pieces of <https://isitagentready.com>. Site-specific content (identity, real URLs, MCP handlers) is intentionally left for downstream consumers like haspar.us to override.

## <isitagentready.com> checks moved

- **Sitemap** — `@astrojs/sitemap` integration emits `/sitemap-index.xml`.
- **robots.txt** — dynamic endpoint using `Astro.site`. Allows `*`, emits explicit rules for GPTBot, ClaudeBot, ClaudeUser, PerplexityBot, Google-Extended, CCBot, Applebot-Extended, Bytespider, Amazonbot (default Allow), plus a `Content-Signals: search, ai-train: yes` policy line and a `Sitemap:` reference.
- **llms.txt / llms-full.txt** — reuse the same MDX glob as `rss.xml.ts`. `llms.txt` is the short index (H1 site name, blurb, `- [title](url): desc` list). `llms-full.txt` concatenates raw post bodies with `# title` headers and `---` separators. Frontmatter fences are stripped. Content-Type: `text/plain; charset=utf-8`.
- **Markdown content negotiation** — `[...path].md.ts` mirrors `[...path].astro`'s `getStaticPaths` and emits the raw MDX body with `Content-Type: text/markdown; charset=utf-8`. Raw bodies come from Vite's `?raw` import query.
- **`<head>` metadata** — `<link rel="canonical">` from `Astro.site + pathname`, `<link rel="alternate" type="text/markdown">` guarded to post routes only, `<script type="application/ld+json">` for `WebSite` (BaseLayout) and `BlogPosting` (PostLayout, via a new named `head` slot).

## New files

- `src/pages/robots.txt.ts`
- `src/pages/llms.txt.ts`
- `src/pages/llms-full.txt.ts`
- `src/pages/[...path].md.ts`
- `src/lib/seo/jsonLd.ts` — typed helpers for `WebSite` + `BlogPosting`
- `src/lib/seo/JsonLd.astro` — tiny component that emits `application/ld+json`
- `e2e/agent-ready.spec.ts` — Playwright coverage (see below)

Site name, blurb, and author are placeholders with `TODO(downstream)` comments.

## Out of scope (intentionally)

MCP endpoints, Web Bot Auth, x402/UCP, any identity-specific metadata. Those belong downstream.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings)
- [x] `pnpm build` — verified `/robots.txt`, `/llms.txt`, `/llms-full.txt`, `/sitemap-index.xml`, and `/features/*.md` all appear in `dist/`
- [x] `pnpm exec playwright test agent-ready` — 7/7 pass. Covers:
  - `/robots.txt` shape + all AI bot rules + Content-Signals + Sitemap line
  - `/sitemap-index.xml` contains a `<sitemap><loc>` reference
  - `/llms.txt` has the H1 + Posts section + at least one `- [title](url)` link
  - `/llms-full.txt` concatenates bodies, strips frontmatter, uses `---` separators
  - `/features/asides.md` starts with `# Asides` and has no frontmatter fence
  - Post page `<head>` has canonical, markdown alt, and both `WebSite` + `BlogPosting` JSON-LD (with expected `headline`, `datePublished`, `mainEntityOfPage`)
  - Homepage has canonical but no markdown alt

https://claude.ai/code/session_01FGbxtFhQLNYk3G3Ls36iz5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasparus/zaduma/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
