### PR TITLE
fix(ci): make case() predicate boolean on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm build
         env:
           OG_IMAGE_SECRET:
-            ${{ case(github.event.pull_request.head.repo.fork,
+            ${{ case(github.event.pull_request.head.repo.fork == true,
             'fork-og-image-secret', secrets.OG_IMAGE_SECRET) }}
 
       - name: Install Playwright browsers


### PR DESCRIPTION
## Summary

On `push` to `main` (and on `workflow_dispatch`), there is no `github.event.pull_request` context, so `github.event.pull_request.head.repo.fork` evaluates to `null`. GitHub's `case()` function strictly requires a boolean predicate and rejects the workflow with:

```
The template is not valid. .github/workflows/ci.yml (Line: 61, Col: 13):
case predicate must evaluate to a boolean value
```

Comparing against `true` coerces the null to `false` and preserves the original intent — fork PRs get the placeholder, everything else gets `secrets.OG_IMAGE_SECRET`.

## Test plan

- [x] Minimal diff (1 line)
- [ ] CI passes on this PR (push event on a non-fork branch should now parse the workflow successfully)

https://claude.ai/code/session_01FGbxtFhQLNYk3G3Ls36iz5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasparus/zaduma/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
