### PR TITLE
chore(ci): improve Vercel deploy diagnostics

### DIFF
--- a/.github/scripts/deploy.mjs
+++ b/.github/scripts/deploy.mjs
@@ -1,42 +1,122 @@
 // @ts-check
 
 // We're building on GitHub Actions instead of Vercel to keep access to Git history.
+//
+// Each `vercel` subcommand runs in its own child process so that a non-zero
+// exit pinpoints exactly which step failed (pull / build / deploy / alias)
+// and surfaces stderr directly in the Actions log. The deployment URL is
+// parsed from `vercel deploy` stdout by picking the last `https://…` line,
+// which is robust to banners or deprecation notices printed by pnpm/vercel.
 
-import { execSync } from "child_process";
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
 import parseArgs from "yargs-parser";
 
 const { token, prod } = parseArgs(process.argv.slice(2));
 
-// 1. Pull vercel environment information
-// 2. Build project artifacts
-// 3. Deploy project artifacts to vercel
-// 4. Alias deployment to ${branch}--zaduma.vercel.app and write to GITHUB_ENV
-execSync(
-  `\
-  pnpm vercel pull \
-    --yes \
-    --token=${token} \
-    --environment=${prod ? "production" : "preview"} && \
-  
-  pnpm vercel build --token=${token} ${prod ? "--prod" : ""} && \
+if (!token) {
+  console.error("deploy.mjs: missing --token");
+  process.exit(2);
+}
 
-  DEPLOYMENT_URL=$(\
-    pnpm vercel deploy \
-      --prebuilt \
-      --token=${token} \
-      ${prod ? "--prod" : ""} \
-  ) && \
+const environment = prod ? "production" : "preview";
 
-  DEPLOYMENT_ALIAS="${createDeploymentAlias()}" && \
-  
-  echo "DEPLOYMENT_ALIAS=$DEPLOYMENT_ALIAS" >> $GITHUB_ENV && \
+/**
+ * Run `pnpm <args...>` and exit the script on failure.
+ *
+ * @param {string} label
+ * @param {string[]} args
+ * @param {{ captureStdout?: boolean }} [opts]
+ * @returns {string} captured stdout (empty string when captureStdout is false)
+ */
+function pnpmRun(label, args, opts = {}) {
+  const redacted = args.map((a) => a.replace(token, "***"));
+  console.log(`\n▶ ${label}: pnpm ${redacted.join(" ")}`);
 
-  pnpm vercel alias $DEPLOYMENT_URL $DEPLOYMENT_ALIAS --token=${token}
-`
-    .split("\n")
-    .filter((s) => s.trim())
-    .join("\n"),
+  const result = spawnSync("pnpm", args, {
+    stdio: opts.captureStdout
+      ? ["inherit", "pipe", "inherit"]
+      : "inherit",
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    console.error(`✗ ${label} failed to spawn: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    console.error(`✗ ${label} exited with code ${result.status}`);
+    if (opts.captureStdout && result.stdout) {
+      console.error("--- stdout ---\n" + result.stdout);
+    }
+    process.exit(result.status ?? 1);
+  }
+
+  return opts.captureStdout ? result.stdout ?? "" : "";
+}
+
+// 1. Pull Vercel environment information.
+pnpmRun("vercel pull", [
+  "vercel",
+  "pull",
+  "--yes",
+  `--token=${token}`,
+  `--environment=${environment}`,
+]);
+
+// 2. Build project artifacts.
+pnpmRun("vercel build", [
+  "vercel",
+  "build",
+  `--token=${token}`,
+  ...(prod ? ["--prod"] : []),
+]);
+
+// 3. Deploy prebuilt artifacts. Capture stdout so we can extract the URL.
+const deployStdout = pnpmRun(
+  "vercel deploy",
+  [
+    "vercel",
+    "deploy",
+    "--prebuilt",
+    `--token=${token}`,
+    ...(prod ? ["--prod"] : []),
+  ],
+  { captureStdout: true },
 );
+
+const deploymentUrl = deployStdout
+  .split(/\r?\n/)
+  .map((l) => l.trim())
+  .reverse()
+  .find((l) => /^https:\/\/\S+$/.test(l));
+
+if (!deploymentUrl) {
+  console.error("✗ could not find a deployment URL in `vercel deploy` output");
+  console.error("--- stdout ---\n" + deployStdout);
+  process.exit(1);
+}
+console.log(`deployment URL: ${deploymentUrl}`);
+
+// 4. Alias the deployment to `${branch}--zaduma.vercel.app` and write the
+//    alias to $GITHUB_ENV so later steps can reference it.
+const deploymentAlias = createDeploymentAlias();
+console.log(`deployment alias: ${deploymentAlias}`);
+
+if (process.env.GITHUB_ENV) {
+  appendFileSync(
+    process.env.GITHUB_ENV,
+    `DEPLOYMENT_ALIAS=${deploymentAlias}\n`,
+  );
+}
+
+pnpmRun("vercel alias", [
+  "vercel",
+  "alias",
+  deploymentUrl,
+  deploymentAlias,
+  `--token=${token}`,
+]);
 
 function createDeploymentAlias() {
   if (!process.env.REF_NAME) throw new Error("process.env.REF_NAME is missing");


### PR DESCRIPTION
## Summary

Splits the Vercel deploy script into per-command child processes so we can tell *which* step failed on the next preview deploy (PR #72 failed here with no visible root cause).

- Each `vercel` subcommand is its own `spawnSync`. On non-zero exit we log the step label and exit code; stderr streams directly to the Actions log instead of being swallowed by `sh -c`.
- `vercel deploy` stdout is captured and the deployment URL is parsed as the last `https://…` line — robust to pnpm/vercel banners that could previously leak into `$DEPLOYMENT_URL` and break `vercel alias`.
- `DEPLOYMENT_ALIAS` is written via `fs.appendFileSync(GITHUB_ENV, …)` instead of a shell redirection.
- Token is redacted in the echoed command (belt-and-suspenders on top of GitHub's automatic masking).
- Fail fast with a clear message when `--token` or `REF_NAME` is missing.

Behavior otherwise unchanged: same subcommands, same flags, same alias shape (`${slug}--zaduma.vercel.app`).

## Why

PR #72's Deploy Preview step failed with only "Process completed with exit code 1" visible, because all four vercel subcommands were chained with `&&` inside a single `sh -c`. Any of them could have failed, and the one that did failed silently. With this change, the next failure will name the step and show the error inline.

## Test plan

- [x] `node --check` on the script
- [x] Dry-run exits cleanly with `deploy.mjs: missing --token` when no token is provided
- [ ] Next preview CI run surfaces the actual Vercel error

https://claude.ai/code/session_01FGbxtFhQLNYk3G3Ls36iz5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasparus/zaduma/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
