### PR TITLE
chore(deps): drop Playwright bump, pin exactly to 1.58.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@astrojs/rss": "^4.0.18",
     "@edgeandnode/eslint-config": "^2.0.3",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.58.2",
     "@types/hast": "3.0.4",
     "@types/node": "20.13.0",
     "autoprefixer": "^10.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3(eslint@8.57.0)(typescript@5.8.3)
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: 1.58.2
+        version: 1.58.2
       '@types/hast':
         specifier: 3.0.4
         version: 3.0.4
@@ -1552,8 +1552,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4516,13 +4516,13 @@ packages:
     peerDependencies:
       sharp: '>= 0.30.6'
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7008,9 +7008,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.58.2':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.58.2
 
   '@renovatebot/pep440@4.2.1': {}
 
@@ -10885,11 +10885,11 @@ snapshots:
     dependencies:
       sharp: 0.32.6
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.58.2: {}
 
-  playwright@1.59.1:
+  playwright@1.58.2:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Reverting @playwright/test from ^1.59.1 back to 1.58.2 (exact pin, no caret). Visual-regression snapshots are baselined against Playwright 1.58.2's bundled chrome-headless-shell; 1.59.1 ships a newer shell whose font metrics shift renders by ~4 px, breaking the snapshots against our CI baseline.

Exact pin prevents silent drift from minor/patch bumps until we're ready to regenerate snapshots.

https://claude.ai/code/session_01FGbxtFhQLNYk3G3Ls36iz5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasparus/zaduma/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
