### PR TITLE
fix(seo): escape `<` in JSON-LD to prevent script-tag breakout

### DIFF
--- a/src/lib/seo/JsonLd.astro
+++ b/src/lib/seo/JsonLd.astro
@@ -4,7 +4,9 @@ interface Props {
 }
 
 const { data } = Astro.props;
-const json = JSON.stringify(data);
+// Escape `<` so a `</script>` substring in any field can't close the tag
+// prematurely (JSON.stringify doesn't escape it).
+const json = JSON.stringify(data).replace(/</g, "\\u003c");
 ---
 
 <script type="application/ld+json" is:inline set:html={json} />


### PR DESCRIPTION
## Summary

\`JSON.stringify\` doesn't escape \`<\`, so any post frontmatter field (title, description) containing \`</script>\` would close the \`<script type="application/ld+json">\` tag prematurely, breaking the page and opening an HTML-injection vector.

### Repro

A post with \`title: "Test</script><script>alert(1)</script>"\` produces:
\`\`\`html
<script type="application/ld+json">{"headline":"Test</script><script>alert(1)</script>"}</script>
\`\`\`

### Fix

Replace \`<\` with \`\u003c\` before \`set:html\`. JSON parsers decode \`\u003c\` back to \`<\` transparently, so schema.org consumers see the original string — but the HTML tokenizer no longer sees \`</script\`.

Same pattern that React's \`renderToString\` uses for inline JSON.

## Test plan

- [x] \`pnpm build\` passes
- [x] Verified: a test post with \`</script>\` in frontmatter no longer breaks out of the JSON-LD script tag in the generated HTML
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hasparus/zaduma/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
