### PR TITLE
Revert "fix(seo): escape `<` in JSON-LD to prevent script-tag breakout"

### DIFF
--- a/src/lib/seo/JsonLd.astro
+++ b/src/lib/seo/JsonLd.astro
@@ -4,9 +4,7 @@ interface Props {
 }
 
 const { data } = Astro.props;
-// Escape `<` so a `</script>` substring in any field can't close the tag
-// prematurely (JSON.stringify doesn't escape it).
-const json = JSON.stringify(data).replace(/</g, "\\u003c");
+const json = JSON.stringify(data);
 ---
 
 <script type="application/ld+json" is:inline set:html={json} />


### PR DESCRIPTION
Reverts hasparus/zaduma#79

This is silly, Claude. `frontmatter` and `title` are user's code.