### PR TITLE
fix(palette): restore translucent backdrop after Tailwind v4 migration

### DIFF
--- a/src/lib/Commands.tsx
+++ b/src/lib/Commands.tsx
@@ -155,7 +155,7 @@ export function CommandsPalette({
       onClose={() => setPage(undefined)}
       ref={(ref) => (dialog = ref)}
       class={
-        "relative mx-auto w-96 max-w-full transform flex-col overflow-hidden rounded-xl bg-white p-0 shadow-2xl ring-1 ring-black ring-opacity-5 transition-all backdrop:bg-white backdrop:bg-opacity-30 dark:bg-gray-900 dark:backdrop:bg-black dark:backdrop:bg-opacity-30 open:flex"
+        "relative mx-auto w-96 max-w-full transform flex-col overflow-hidden rounded-xl bg-white p-0 shadow-2xl ring-1 ring-black/5 transition-all backdrop:bg-white/30 dark:bg-gray-900 dark:backdrop:bg-black/30 open:flex"
       }
     >
       <div class="flex justify-end">


### PR DESCRIPTION
## Problem
Opening the command palette painted a fully **opaque black backdrop**, hiding the page (and posts list) behind it. On prod (haspar.us) the backdrop is a 30% dim.

## Cause
Tailwind v4 removed `bg-opacity-*` / `ring-opacity-*` utilities. The `@tailwindcss/upgrade` codemod converted bare ones but **skipped those behind a variant prefix** (`backdrop:bg-opacity-30`), so they silently no-op'd → backdrop stayed at full alpha.

## Fix
Convert to v4 slash-alpha on `Commands.tsx:158`:
- `ring-black ring-opacity-5` → `ring-black/5`
- `backdrop:bg-white backdrop:bg-opacity-30` → `backdrop:bg-white/30`
- `dark:backdrop:bg-black dark:backdrop:bg-opacity-30` → `dark:backdrop:bg-black/30`

Grep-swept `src` — this was the only straggler. Posts-list hover verified unaffected (prod vs local identical). typecheck + lint clean.

## Verify
Open palette (⌘K) — page is now dimmed/visible behind it instead of solid black.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated component styling syntax for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->