### PR TITLE
Propagate consumer fixes (MDXInstance props, git-log/fetch guards)

### DIFF
--- a/src/build-time/derivedTitleAndDatePlugin.tsx
+++ b/src/build-time/derivedTitleAndDatePlugin.tsx
@@ -13,21 +13,26 @@ export const derivedTitleAndDatePlugin: Plugin<
     frontmatter.title ||= title(file.stem || "");
 
     if (!frontmatter.date) {
-      const createdAt =
-        execFileSync(
-          "git",
-          [
-            "log",
-            "--follow",
-            "--diff-filter=A",
-            "--find-renames=40%",
-            "--format=%ai",
-            file.path,
-          ],
-          { encoding: "utf8" },
-        )
-          .trim()
-          .split("\n")[0] || new Date().toISOString();
+      let createdAt: string;
+      try {
+        createdAt =
+          execFileSync(
+            "git",
+            [
+              "log",
+              "--follow",
+              "--diff-filter=A",
+              "--find-renames=40%",
+              "--format=%ai",
+              file.path,
+            ],
+            { encoding: "utf8" },
+          )
+            .trim()
+            .split("\n")[0] || new Date().toISOString();
+      } catch {
+        createdAt = new Date().toISOString();
+      }
 
       frontmatter.date = createdAt;
     }

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,5 +1,5 @@
 ---
-import type { MarkdownLayoutProps } from "astro";
+import type { MarkdownHeading, MDXInstance } from "astro";
 
 import { createOgImageLink } from "../lib/createOgImageLink";
 import { formatDate } from "../lib/formatDate";
@@ -13,8 +13,9 @@ import BaseLayout from "./BaseLayout.astro";
 
 import "../global-styles/shiki.css";
 
-interface Props extends Omit<MarkdownLayoutProps<{}>, "frontmatter"> {
+interface Props extends Omit<MDXInstance<{}>, "frontmatter"> {
   frontmatter: PostFrontmatter;
+  headings: MarkdownHeading[];
 }
 
 const { frontmatter, headings } = Astro.props;

--- a/src/lib/prose/Image.astro
+++ b/src/lib/prose/Image.astro
@@ -120,6 +120,11 @@ if (isRaw) {
   let imageForPlaceholder: Buffer;
   if (pathToImage.startsWith("http")) {
     const res = await fetch(pathToImage);
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch image ${pathToImage}: ${res.status} ${res.statusText}`,
+      );
+    }
     imageForPlaceholder = Buffer.from(await res.arrayBuffer());
   } else {
     // Resolve the source image from the project root. `pathToImage` is


### PR DESCRIPTION
Small template hardening for issues found while bridging these fixes into loudmouth (#53) and homepage (#63), so future syncs don't re-seed them.

- **PostLayout props** → `Omit<MDXInstance<{}>, "frontmatter"> & { frontmatter; headings }`. The old `MarkdownLayoutProps` mismatches the MDX modules `[...path].astro` spreads; `astro check` (exactOptionalPropertyTypes) flags it. zaduma's typecheck is `tsc --noEmit` only, so it's latent here — but consumers that run `astro check` (loudmouth) hit it.
- **derivedTitleAndDatePlugin**: `execFileSync` git-log now guarded — falls back to current date if git/.git is absent instead of failing the build.
- **Image.astro**: throw on non-ok remote fetch instead of passing an error body to `getPlaiceholder`.

Verified: `tsc --noEmit` 0 errors, lint clean, build 10 pages.