### PR TITLE
Add og:url meta tag

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -81,6 +81,7 @@ const websiteData = websiteSchema({
 
     <SocialCardMetaTags ogImage={ogImage} />
 
+    <meta property="og:url" content={canonical} />
     <link rel="canonical" href={canonical} />
     {
       isPostRoute && (


### PR DESCRIPTION
Blog posts (and all pages) were missing `og:url`. Add it in BaseLayout reusing the existing `canonical` URL, so it stays in sync with the canonical link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Open Graph URL tag to improve how shared pages appear in link previews and social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->